### PR TITLE
feat: GPT-Image-1 edge function

### DIFF
--- a/netlify/edge-functions/generateImage.ts
+++ b/netlify/edge-functions/generateImage.ts
@@ -1,0 +1,44 @@
+/// <reference types="@netlify/edge-functions" />
+
+import type { Context } from "@netlify/edge-functions";
+
+declare global {
+  const Netlify: {
+    env: {
+      get(key: string): string | undefined;
+    };
+  };
+}
+
+export default async (req: Request, _ctx: Context) => {
+  // Read the prompt JSON { prompt: "..." }
+  const { prompt } = await req.json();
+
+  // Call OpenAI Images API (GPT-Image-1)
+  const apiRes = await fetch("https://api.openai.com/v1/images/generations", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${Netlify.env.get("VITE_OPENAI_API_KEY")}`, // 🔐 secret stays on the edge
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      model: "gpt-image-1",   // same model ID shown in the official docs :contentReference[oaicite:0]{index=0}
+      prompt,
+      n: 1,
+      size: "1024x1024"       // 512×512 and 2048×2048 are also allowed :contentReference[oaicite:1]{index=1}
+    })
+  });
+
+  if (!apiRes.ok) {
+    return new Response(
+      `OpenAI error ${apiRes.status}: ${await apiRes.text()}`,
+      { status: apiRes.status }
+    );
+  }
+
+  // Forward the JSON payload ({ created, data:[{url|b64_json}] })
+  const data = await apiRes.json();
+  return new Response(JSON.stringify(data), {
+    headers: { "content-type": "application/json" }
+  });
+};


### PR DESCRIPTION
🗒️ What this PR does
Adds a Netlify Edge Function

Created netlify/edge-functions/generateImage.ts that calls the OpenAI Images API (/v1/images/generations) with model: "gpt-image-1", returning the JSON (signed URL or b64_json). 
[docs.netlify.com](https://docs.netlify.com/edge-functions/get-started/?utm_source=chatgpt.com)
[platform.openai.com](https://platform.openai.com/docs/guides/image-generation?utm_source=chatgpt.com)

Uses the built-in Fetch API available in Edge Functions. 
[docs.netlify.com](https://docs.netlify.com/edge-functions/overview/?utm_source=chatgpt.com)

Keeps the OpenAI key server-side

Reads VITE_OPENAI_API_KEY at runtime via Netlify.env.get, so the secret never ships to the browser. 
[edge-functions-examples.netlify.app](https://edge-functions-examples.netlify.app/example/environment?utm_source=chatgpt.com)
[docs.netlify.com](https://docs.netlify.com/environment-variables/overview/?utm_source=chatgpt.com)

Key is configured in Site settings › Environment variables. 
[docs.netlify.com](https://docs.netlify.com/functions/environment-variables/?utm_source=chatgpt.com)

Type-safe development setup

Installed @netlify/edge-functions types to expose the global Netlify object and Context interface. 
[platform.openai.com](https://platform.openai.com/docs/guides/images/usage?lang=curl&utm_source=chatgpt.com)

Extended tsconfig.node.json with "lib": ["ES2023","DOM"] for fetch/Request/Response and added the e2e/**/*.d.ts test declarations.

Branch & deploy flow

Feature branch feature/my-change holds the new function; merging to main triggers a Netlify production build automatically. 
[docs.netlify.com](https://docs.netlify.com/site-deploys/overview/?utm_source=chatgpt.com)
[docs.netlify.com](https://docs.netlify.com/site-deploys/deploy-previews/?utm_source=chatgpt.com)

Optionally supports Branch Deploys for review URLs. 
[docs.netlify.com](https://docs.netlify.com/domains/manage-domains/manage-domains-for-branch-deploys/?utm_source=chatgpt.com)

Local developer UX

netlify dev reproduces the Edge runtime locally for instant testing; no CORS issues. 
[docs.netlify.com](https://docs.netlify.com/cli/local-development/?utm_source=chatgpt.com)